### PR TITLE
feat: add refresh pinned to external message listener

### DIFF
--- a/src/components/Input/InputPromptActions.tsx
+++ b/src/components/Input/InputPromptActions.tsx
@@ -123,8 +123,6 @@ const InputPromptActions = ({ input }: { input: string }) => {
     return acc
   }, [])
 
-  console.log({ isLoadingPrompts, pinnedPrompts })
-
   if (isLoadingPrompts || !userId) {
     return (
       <motion.div variants={actionItemVariants} initial="hidden" animate="show" exit="exit">

--- a/src/hooks/useOnExternalMessage.ts
+++ b/src/hooks/useOnExternalMessage.ts
@@ -31,12 +31,18 @@ const useOnExternalMessage = () => {
   const { handleSubmit } = useSubmitQuery()
   const { forkDefaultAction } = useForkDefaultAction()
   const { createAction } = useIntegration()
-  const { selectPrompt } = usePromptApps()
+  const { selectPrompt, refreshPinnedPrompts } = usePromptApps()
 
   useEffect(() => {
     const removeListener = Highlight.app.addListener('onExternalMessage', async (caller: string, message: any) => {
       console.log('Received external message from:', caller)
       console.log('Message content:', message)
+
+      if (message.type === 'refresh-pinned-prompts') {
+        await refreshPinnedPrompts(true)
+        console.log('Refreshed prompts')
+        return
+      }
 
       if (message.conversationId) {
         console.log('Opening conversation from external event:', message.conversationId)

--- a/src/hooks/usePromptApps.ts
+++ b/src/hooks/usePromptApps.ts
@@ -90,7 +90,7 @@ export default (loadPrompts?: boolean) => {
     return loadPromptsPromise
   }
 
-  const refreshPinnedPrompts = async () => {
+  const refreshPinnedPrompts = async (skipInternalCall?: boolean) => {
     const pinned = await fetchPinnedPrompts(await getAccessToken())
     // @ts-ignore
     if (Array.isArray(pinned)) {
@@ -98,6 +98,7 @@ export default (loadPrompts?: boolean) => {
     }
 
     try {
+      if (skipInternalCall) return
       //@ts-expect-error
       globalThis.highlight.internal.reloadPrompts()
     } catch (err) {


### PR DESCRIPTION
Adds a new message to listen for from floaty. 

- Added a `skipInternal` flag to refresh pinned prompts so we don't get an endless loop of floaty fetching prompts -> sending base app the refresh prompts event -> base app refreshing and sending floaty an internal event to fetch prompts -> ect...

Pairs with this PR from floaty https://github.com/highlight-ing/highlight/pull/1997