### PR TITLE
Use new integration endpoints

### DIFF
--- a/src/features/integrations/google-cal/actions.ts
+++ b/src/features/integrations/google-cal/actions.ts
@@ -1,11 +1,6 @@
 'use server'
 
-import { google } from 'googleapis'
-import { v4 as uuidv4 } from 'uuid'
-
-import type { CreateGoogleCalendarEventParams } from '../_hooks/use-integrations'
-
-const HIGHLIGHT_BACKEND_BASE_URL = 'https://backend.highlightai.com'
+import { HIGHLIGHT_BACKEND_BASE_URL } from '@/lib/integrations-backend'
 
 export async function checkGoogleConnectionStatus(accessToken: string) {
   const response = await fetch(`${HIGHLIGHT_BACKEND_BASE_URL}/v1/connections`, {
@@ -89,49 +84,4 @@ export async function createMagicLinkForGoogle(accessToken: string) {
   }
 
   return data.url
-}
-
-export async function createGoogleCalendarEvent(accessToken: string, data: CreateGoogleCalendarEventParams) {
-  const gToken = await getGoogleTokenForUser(accessToken)
-
-  const oauth2Client = new google.auth.OAuth2(
-    process.env.GOOGLE_CLIENT_ID,
-    process.env.GOOGLE_CLIENT_SECRET,
-    process.env.GOOGLE_REDIRECT_URL,
-  )
-
-  oauth2Client.setCredentials({
-    access_token: gToken,
-  })
-
-  const calendar = google.calendar({ version: 'v3', auth: oauth2Client })
-
-  const event = await calendar.events.insert({
-    auth: oauth2Client,
-    calendarId: 'primary',
-    conferenceDataVersion: data.includeGoogleMeetDetails ? 1 : 0,
-    requestBody: {
-      summary: data.summary,
-      description: data.description,
-      start: {
-        dateTime: data.start,
-      },
-      end: {
-        dateTime: data.end,
-      },
-      location: data.location,
-      conferenceData: data.includeGoogleMeetDetails
-        ? {
-            createRequest: {
-              conferenceSolutionKey: {
-                type: 'hangoutsMeet',
-              },
-              requestId: uuidv4(),
-            },
-          }
-        : undefined,
-    },
-  })
-
-  return event.data.htmlLink
 }

--- a/src/features/integrations/linear/actions.ts
+++ b/src/features/integrations/linear/actions.ts
@@ -85,11 +85,3 @@ export async function checkLinearConnectionStatus(accessToken: string) {
 
   return data.connected
 }
-
-export async function createLinearClientForUser(userId: string) {
-  // Make an outgoing fetch request to Highlight backend to get the user's Linear API key
-  // const linearToken = await getLinearTokenForUser(userId)
-  // return new LinearClient({
-  //   accessToken: linearToken,
-  // })
-}

--- a/src/features/integrations/linear/hooks.ts
+++ b/src/features/integrations/linear/hooks.ts
@@ -1,40 +1,11 @@
-import { LinearClient } from '@linear/sdk'
+import type { User, WorkflowState } from '@linear/sdk'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
+import { HIGHLIGHT_BACKEND_BASE_URL } from '@/lib/integrations-backend'
+
 import { useHighlightToken } from '../_hooks/use-hl-token'
-import { checkLinearConnectionStatus, getLinearTokenForUser } from './actions'
+import { checkLinearConnectionStatus } from './actions'
 import { LinearTicketFormSchema } from './linear'
-
-export function useLinearApiToken() {
-  const { data: hlToken } = useHighlightToken()
-
-  return useQuery({
-    queryKey: ['linear-api-token'],
-    queryFn: async () => {
-      const linearToken = await getLinearTokenForUser(hlToken as string)
-
-      if (!linearToken) {
-        console.warn('Something is wrong, no Linear token found for user but we are in the Linear form')
-        throw new Error('No Linear token found')
-      }
-
-      return linearToken
-    },
-    enabled: !!hlToken,
-    staleTime: 2 * 60 * 1000,
-  })
-}
-
-export function useLinearClient() {
-  const { data: linearToken } = useLinearApiToken()
-
-  return useQuery({
-    queryKey: ['linear-client', linearToken],
-    queryFn: () => new LinearClient({ accessToken: linearToken }),
-    enabled: !!linearToken,
-    staleTime: Infinity,
-  })
-}
 
 export function useCheckLinearConnection() {
   const { data: hlToken } = useHighlightToken()
@@ -54,116 +25,106 @@ export function useCheckLinearConnection() {
   })
 }
 
-export function useLinearTeams() {
-  const { data: client } = useLinearClient()
-
-  return useQuery({
-    queryKey: ['linear-teams'],
-    queryFn: async () => {
-      if (!client) {
-        throw new Error('No Linear client available')
-      }
-
-      const me = await client.viewer
-      const teams = await me.teams()
-
-      return teams.nodes
-    },
-    enabled: !!client,
-    staleTime: 2 * 60 * 1000,
-  })
+interface LinearStatusesResponse {
+  statuses: WorkflowState[]
 }
 
 export function useLinearWorkflowStates() {
-  const { data: client } = useLinearClient()
+  const { data: hlToken } = useHighlightToken()
 
   return useQuery({
     queryKey: ['linear-workflow-states'],
     queryFn: async () => {
-      if (!client) {
-        throw new Error('No Linear client available')
+      if (!hlToken) {
+        throw new Error('No Highlight token available')
       }
 
-      const workflowStates = await client.workflowStates()
+      const response = await fetch(`${HIGHLIGHT_BACKEND_BASE_URL}/v1/linear/statuses`, {
+        headers: {
+          Authorization: `Bearer ${hlToken}`,
+        },
+      })
 
-      return workflowStates.nodes.sort((a, b) => a.position - b.position)
+      if (!response.ok) {
+        const responseText = await response.text()
+        throw new Error(`Failed to fetch Linear statuses: ${responseText}`)
+      }
+
+      const data = (await response.json()) as LinearStatusesResponse
+
+      return data.statuses.sort((a, b) => a.position - b.position)
     },
-    enabled: !!client,
+    enabled: !!hlToken,
     staleTime: 2 * 60 * 1000,
   })
 }
 
+interface LinearAssigneesResponse {
+  assignees: User[]
+}
+
 export function useLinearAssignees() {
-  const { data: client } = useLinearClient()
+  const { data: hlToken } = useHighlightToken()
 
   return useQuery({
     queryKey: ['linear-assignees'],
     queryFn: async () => {
-      if (!client) {
-        throw new Error('No Linear client available')
+      if (!hlToken) {
+        throw new Error('No Highlight token available')
       }
 
-      const assignees = await client.users()
+      const response = await fetch(`${HIGHLIGHT_BACKEND_BASE_URL}/v1/linear/assignees`, {
+        headers: {
+          Authorization: `Bearer ${hlToken}`,
+        },
+      })
 
-      return assignees.nodes.sort((a, b) => a.displayName.localeCompare(b.displayName))
+      const data = (await response.json()) as LinearAssigneesResponse
+
+      return data.assignees
     },
-    enabled: !!client,
+    enabled: !!hlToken,
     staleTime: 2 * 60 * 1000,
   })
 }
 
+interface CreateLinearTicketResponse {
+  url: string
+}
+
 export function useCreateLinearTicket(onSubmitSuccess: ((url: string) => void) | undefined) {
-  const { data: client } = useLinearClient()
-  const { data: teams } = useLinearTeams()
   const { data: hlToken } = useHighlightToken()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationKey: ['create-linear-ticket'],
-    mutationFn: async (data: LinearTicketFormSchema) => {
+    mutationFn: async (input: LinearTicketFormSchema) => {
       if (!hlToken) {
-        throw new Error('No Linear token available')
+        throw new Error('No Highlight token available')
       }
 
-      const connected = await checkLinearConnectionStatus(hlToken)
+      const response = await fetch(`${HIGHLIGHT_BACKEND_BASE_URL}/v1/linear/ticket`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${hlToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title: input.title,
+          description: input.description,
+          assignee: input.assignee,
+          status: input.status,
+        }),
+      })
 
-      if (!connected) {
-        throw new Error('Not connected to Linear')
+      if (!response.ok) {
+        const responseText = await response.text()
+        throw new Error(`Failed to create Linear ticket: ${responseText}`)
       }
 
-      const team = teams?.[0]
+      const data = (await response.json()) as CreateLinearTicketResponse
 
-      if (!team?.id) {
-        throw new Error('No team found')
-      }
-
-      let payload = {
-        teamId: team.id,
-        title: data.title,
-        description: data.description,
-      }
-
-      if (data.assignee) {
-        payload = Object.assign(payload, {
-          assigneeId: data.assignee,
-        })
-      }
-
-      if (data.status) {
-        payload = Object.assign(payload, {
-          stateId: data.status,
-        })
-      }
-
-      const issuePayload = await client?.createIssue(payload)
-
-      const issueUrl = (await issuePayload?.issue)?.url
-
-      if (!issueUrl) {
-        throw new Error('Something went wrong, no issue URL returned')
-      }
-
-      return issueUrl
+      return data.url
     },
     onSuccess: (issueUrl) => {
       if (onSubmitSuccess) onSubmitSuccess(issueUrl)

--- a/src/features/integrations/notion/hooks.ts
+++ b/src/features/integrations/notion/hooks.ts
@@ -53,8 +53,6 @@ export function useNotionParentItems() {
 
       const items = (await response.json()) as NotionParentResponse
 
-      console.log('Items', items)
-
       return items.parents
     },
     enabled: !!hlToken,

--- a/src/lib/integrations-backend.ts
+++ b/src/lib/integrations-backend.ts
@@ -1,0 +1,1 @@
+export const HIGHLIGHT_BACKEND_BASE_URL = 'https://backend.highlightai.com'


### PR DESCRIPTION
To keep the system standardized, highlight-chat should call the new integration endpoints instead of doing it manually